### PR TITLE
fix: squash when merging update PRs to linearise history

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Enable Auto-Merge
         if: env.dependencies_changed == 'true'
-        run: gh pr merge --merge --auto "${PR:?}"
+        run: gh pr merge --squash --auto "${PR:?}"
         env:
           PR: ${{ steps.create-pr.outputs.pull-request-number}}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
The repo is configured to require linear history, and unlike in the UI the gh CLI doesn't automatically squash or rebase when merging a PR.