### PR TITLE
fix: allow PRs without docker/* changes to merge

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,0 +1,23 @@
+# This workflow only exists to cause the required "Built & Test" status check
+# to have passed in PRs without changes to files in docker/*. PRs with changes
+# to docker/* files are handled by test-images.
+#
+# The the test-images workflow never starts in PRs without docker/* changes, so
+# without this workflow, the PR waits forever for the un-started required
+# status check. See:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: "Test non-image changes"
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "docker/*"
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"


### PR DESCRIPTION
Currently PRs without changes to docker/* files can't be merged, because we have a required status check for the "Test & Build" job, but this job is only started when docker/* files change.

We have to explicitly run a "Test & Build" job in such a case, GitHub doesn't automatically infer that the build wasn't required. To do this we have a no-op workflow that only runs a PR has no docker/* changes.

See the GitHub docs on this scenario:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks